### PR TITLE
Feat - add optional route hash at end of attachment

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,6 +38,7 @@ export const DEFAULT_SETTINGS: ANFSettings = {
 	copyPathMode: "Relative",
 	usingLog: false,
 	logPath: "/",
+	appendPathHash: false,
 };
 
 export const ATTACHMENT_TYPE = ["image", "audio", "video", "pdf"];

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { FolderScanModal, FolderRenameWarningModal } from "./modals";
 import * as path from "path";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = require("fs");
+const crypto = require("crypto");
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const JSZip = require("jszip");
 
@@ -402,6 +403,16 @@ export default class AttachmentNameFormatting extends Plugin {
 								("0" + timeInterval.getMinutes()).slice(-2) +
 								("0" + timeInterval.getSeconds()).slice(-2);
 							baseNameComponent.push(date_String);
+						}
+
+						if (this.settings.appendPathHash) {
+							const appendPathHashValue = crypto
+								.createHash("md5")
+								.update(file.parent.path)
+								.digest("hex")
+								.slice(0, 8);
+
+							baseNameComponent.push(appendPathHashValue);
 						}
 
 						// Generater full new name without path

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -211,6 +211,20 @@ export class ANFSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
+			.setName("Add path hash at end of attachment name")
+			.setDesc(
+				"Add path has at end of attachment name. This helps with uniqueness when you have multiple notes with the same name."
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.appendPathHash)
+					.onChange(async (value) => {
+						this.plugin.settings.appendPathHash = value;
+						await this.plugin.saveSettings();
+					});
+			});
+
+		new Setting(containerEl)
 			.setName("Automatic formatting")
 			.setDesc(
 				"Automatic formatting the attachments' name when changing note content"

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -213,7 +213,7 @@ export class ANFSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Add path hash at end of attachment name")
 			.setDesc(
-				"Add path has at end of attachment name. This helps with uniqueness when you have multiple notes with the same name."
+				"For uniqueness in attachment names if there are note files with the same name (but at different levels)"
 			)
 			.addToggle((toggle) => {
 				toggle

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface ANFSettings {
 	copyPathMode: string;
 	usingLog: boolean;
 	logPath: string;
+	appendPathHash: boolean;
 }
 
 export interface ExtensionList {


### PR DESCRIPTION
https://github.com/JYC333/obsidian-attachment-name-formatting/issues/32

Screenshot:
![image](https://github.com/JYC333/obsidian-attachment-name-formatting/assets/48156230/287312fe-c32c-4672-81cc-c88ffc9d54a9)

![image](https://github.com/JYC333/obsidian-attachment-name-formatting/assets/48156230/8528fb47-ed43-4837-b5ac-582d9c5ed26e)
